### PR TITLE
test: apps using react-native-tab-view cannot test using fireEvent.press

### DIFF
--- a/App.test.js
+++ b/App.test.js
@@ -4,13 +4,22 @@ import {render, fireEvent} from '@testing-library/react-native';
 import App from './App';
 
 test('Should present the route title on scene content', async () => {
-  const {toJSON, getByLabelText, getByText, queryByText} = render(<App />);
-
-  expect(toJSON()).toMatchSnapshot(); // only first scene rendered
+  const {getByLabelText, getByText, queryByText} = render(<App />);
 
   expect(getByText('First route')).toBeDefined();
 
   fireEvent.press(getByLabelText('Second'), {});
+
+  expect(getByText('Second route')).toBeDefined();
+  expect(await queryByText('First route')).toBeNull();
+});
+
+test('fireEvent.press should switch the tab', async () => {
+  const {getByLabelText, getByText, queryByText} = render(<App />);
+
+  expect(getByText('First route')).toBeDefined();
+
+  fireEvent.press(getByLabelText('Second')); // This doesn't work because of e.metaKey etc
 
   expect(getByText('Second route')).toBeDefined();
   expect(await queryByText('First route')).toBeNull();


### PR DESCRIPTION
For apps using react-native-tab-view@4.0.0-rc1

- `fireEvent.press(pressable)` will throw an error
- `fireEvent.press(pressable, {})` will work 